### PR TITLE
Unintended blank Windows  in linux environment is solved

### DIFF
--- a/MathTutor/RootWindow.qml
+++ b/MathTutor/RootWindow.qml
@@ -1,7 +1,6 @@
 // Copyright (C) 2021 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial
 
-
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
@@ -11,193 +10,87 @@ import QtMultimedia
 
 import io.qt.textproperties 1.0
 
-ApplicationWindow{
-
-    id:root
-    Material.theme:mathScreen.theme === 1 ? Material.Dark : Material.Light
+ApplicationWindow {
+    id: root
+    visible: true   
+    width: 300
+    height: 200
     Material.accent: Material.Red
     title: "Zendlona Math Tutor App"
-    visible: true
-    height: 200
-    width: 300
-    opacity: 0
 
     property var pr_var: bridge.a
-    Component.onCompleted: {
-        console.log("from qml", bridge.getText())
-        console.log("from qml1", bridge.getColor("red"))
 
-        bridge.textChanged()
-       // console.log("from qml2", pr_var)
-        bridge.asetter = [1,2,3]
-        bridge.appendValue(7)
+    Component.onCompleted: {
+        Material.theme = mathScreen.theme === 1 ? Material.Dark : Material.Light
+        languageSelectionScreen.visible = true   
     }
 
     onPr_varChanged: {
         console.log("from qml3", pr_var)
     }
 
-
-
-    ApplicationWindow{
+    // Language Selection Screen (Shown First)
+    Item {
         id: languageSelectionScreen
-        visible: true
-        title: "Zendlona Math Tutor App"
-        maximumHeight:  200
-        maximumWidth:  300
-        minimumHeight: 200
-        minimumWidth: 300
-        onClosing: {
-            if(welcomeScreenWindow.visible ===false ){
-                root.close()
-            }
-        }
+        width: parent.width
+        height: parent.height
+        visible: true  
 
-        Item{
+        Column {
+            anchors.centerIn: parent
+            spacing: 10
 
-            Text{
-                id: languageSelectionText
+            Text {
                 text: "Select Language"
-                anchors{
-                    left: parent.left
-                    leftMargin: 10
-                    top: parent.top
-                    topMargin: 30
-                }
+                font.pixelSize: 16
                 color: Material.primaryTextColor
+                horizontalAlignment: Text.AlignHCenter
             }
-            //a drop down menu to select language
-            ComboBox{
+
+            ComboBox {
                 id: languageComboBox
                 model: ["English", "Hindi", "Marathi"]
                 currentIndex: 0
-                height: 32
-                anchors{
-                    left: languageSelectionText.left
-                    leftMargin: 100
-                    top: parent.top
-                    topMargin: 25
-                }
+                width: 150
                 onCurrentIndexChanged: {
                     console.log("Selected Language: ", languageComboBox.currentText)
                 }
             }
-            //a remeber selection CheckBox
-            CheckBox{
+
+            CheckBox {
                 id: rememberSelection
                 text: "Remember Selection"
                 checked: false
-                anchors{
-                    left: languageSelectionText.left
-                    leftMargin: 10
-                    top: languageComboBox.bottom
-                    topMargin: 10
-                }
-                onClicked: {
-                    rememberSelection.checked = !rememberSelection.checked
-                }
-                onPressed: {
-                    rememberSelection.checked = !rememberSelection.checked
-                }
-
-                Keys.onEnterPressed: {
-                    rememberSelection.checked = !rememberSelection.checked
-                }
-                Keys.onReturnPressed: {
-                    rememberSelection.checked = !rememberSelection.checked
-                }
-
             }
-            //a ok button to move to next screen
-            Button{
-                id: okButton
-                text: "OK"
-                anchors{
-                    left: languageSelectionText.left
-                    leftMargin: 10
-                    top: rememberSelection.bottom
-                    topMargin: 10
+
+            Row {
+                spacing: 10
+                Button {
+                    text: "OK"
+                    onClicked: {
+                        if (rememberSelection.checked) {
+                            console.log("Remembered")
+                        } else {
+                            console.log("Not Remembered")
+                        }
+
+                        languageSelectionScreen.visible = false  // Hide language selection
+                        mathScreen.visible = true  
+                        root.showMaximized() 
+                    }
                 }
-                onClicked: {
-                    if(rememberSelection.checked){
-                        console.log("Remembered")
-                    }
-                    else{
-                        console.log("Not Remembered")
-                    }
-                    root.visibility= Window.Maximized
-                    root.minimumHeight= 720
-                    root.minimumWidth= 1080
-                    welcomeScreenWindow.visible= true
-                    welcomeScreenWindow.visibility= Window.Maximized
-                    languageSelectionScreen.close()
-                }
-                Keys.onEnterPressed: {
-                    if(rememberSelection.checked){
-                        console.log("Remembered")
-                    }
-                    else{
-                        console.log("Not Remembered")
-                    }
-                    root.visibility= Window.Maximized
-                    root.minimumHeight= 720
-                    root.minimumWidth= 1080
-                    welcomeScreenWindow.visible= true
-                    welcomeScreenWindow.visibility= Window.Maximized
-                    languageSelectionScreen.close()
-                }
-                Keys.onReturnPressed: {
-                    if(rememberSelection.checked){
-                        console.log("Remembered")
-                    }
-                    else{
-                        console.log("Not Remembered")
-                    }
-                    root.visibility= Window.Maximized
-                    root.minimumHeight= 720
-                    root.minimumWidth= 1080
-                    welcomeScreenWindow.visible= true
-                    welcomeScreenWindow.visibility= Window.Maximized
-                    languageSelectionScreen.close()
-                }
-            }
-            //a cancel button to close the application
-            Button{
-                id: cancelButton
-                text: "Cancel"
-                anchors{
-                    left: okButton.right
-                    leftMargin: 10
-                    top: rememberSelection.bottom
-                    topMargin: 10
-                }
-                onClicked: {
-                    root.close()
+                Button {
+                    text: "Cancel"
+                    onClicked: Qt.quit()
                 }
             }
         }
     }
 
-
-
-    ApplicationWindow{
-        id: welcomeScreenWindow
-        minimumHeight: 720
-        minimumWidth: 1080
-        title: "Zendlona Math Tutor App"
-        //visibility: Window.Maximized
-        //close this window until the language is selected
-        visible: false
-        onClosing: {
-            root.close()
-        }
-
-        MathScreen{
-            id: mathScreen
-            anchors.fill: parent
-            visible: true
-        }
+    // Main Math Screen (Hidden Initially)
+    MathScreen {
+        id: mathScreen
+        anchors.fill: parent
+        visible: false  
     }
 }
-
-


### PR DESCRIPTION

This commit removes the unintended blank window on WSL/Linux and refines the screen transition logic between the Language Selection Screen and the Main Math Screen.


Optimized Screen Transition Logic:
The Language Selection Screen (languageSelectionScreen) is now properly hidden once a language is selected.
The Main Math Screen (mathScreen) becomes visible only after language selection, ensuring a smoother transition.




📌 Next Steps:
I have noted some improvements needed in app sizing, but I would like to discuss the idea before making any changes. Let me know your thoughts before proceeding!